### PR TITLE
Generalizing parsing for GGA, RMC strings

### DIFF
--- a/GPS.cpp
+++ b/GPS.cpp
@@ -238,7 +238,13 @@ uint8_t GPS::parse(const char* nmea, const uint32_t now)
     if (strstr(nmea, "$GPGGA") == nmea) {
         if (strlen(nmea) < 65) return PARSED_UNKNOWN; // No fix
         return parseGGA(nmea, now);
-    } else if (strstr(nmea, "$GPRMC") == nmea) {
+    } else if (strstr(nmea, "$GNGGA") == nmea) { // If GPGGA is not found, check for GNGGA
+        if (strlen(nmea) < 65) return PARSED_UNKNOWN; // No fix
+        return parseGGA(nmea, now);
+    } else if (strstr(nmea, "$GPRMC") == nmea) { 
+        if (strlen(nmea) < 65) return PARSED_UNKNOWN; // No fix
+        return parseRMC(nmea, now);
+    } else if (strstr(nmea, "$GNRMC") == nmea) { // If GPRMC is not found, check for GNRMC
         if (strlen(nmea) < 65) return PARSED_UNKNOWN; // No fix
         return parseRMC(nmea, now);
     } else if (strstr(nmea, "$PMTK001") == nmea) {


### PR DESCRIPTION
The current version of the code parses only `GPGGA` and `GPRMC` strings received from the GPS module. Here, I have made a tweak to make the library generic, so that it can also parse `GNGGA` and `GNRMC` strings.

**Changelog**:
- Some GPS module give **GNGGA** and **GNRMC** strings instead of **GPGGA** and **GPRMC** respectively
- These cases are handled in this PR, generalizing the GPS library for any module

The code is well tested with Skytraq module on Teensy.

